### PR TITLE
Build-989 Button QA Fix

### DIFF
--- a/src/base/_base.scss
+++ b/src/base/_base.scss
@@ -64,7 +64,7 @@ span.BtnSecondary {
   transition: all 400ms ease-in-out;
   font-family: $font-secondary;
   letter-spacing: 10%;
-  font-size: 1.25rem !important;
+  font-size: 1.25rem;
   a {
     color: $color-black;
     line-height: 1;

--- a/src/base/_base.scss
+++ b/src/base/_base.scss
@@ -57,13 +57,13 @@ span.BtnSecondary {
   width: max-content;
   border-radius: 0;
   color: $color-black;
-  font-weight: 600;
+  font-weight: 400;
   box-sizing: border-box;
   line-height: 1;
   transition: all 400ms ease-in-out;
   font-family: $font-secondary;
   letter-spacing: 10%;
-  font-size: 1.25rem;
+  font-size: 1.25rem !important;
   a {
     color: $color-black;
     line-height: 1;

--- a/src/base/_base.scss
+++ b/src/base/_base.scss
@@ -75,7 +75,7 @@ span.BtnSecondary {
   border: 2px solid $color-orange;
   background: $color-orange;
   color: $color-white;
-  padding: 20px 40px;
+  padding: 1.25rem 2.5rem;
   max-width: 100%;
   letter-spacing: 0.1em;
   font-weight: 400;

--- a/src/base/_base.scss
+++ b/src/base/_base.scss
@@ -74,8 +74,11 @@ span.BtnSecondary {
   border: 2px solid $color-orange;
   background: $color-orange;
   color: $color-white;
-  padding: 0.7em 1.15em;
+  padding: 20px 40px;
   max-width: 100%;
+  letter-spacing: 0.1em;
+  font-weight: 400;
+  text-transform: uppercase;
 
   &:hover {
     border-color: $color-black;

--- a/src/base/_base.scss
+++ b/src/base/_base.scss
@@ -53,6 +53,7 @@ span.BtnSecondary {
   display: flex;
   justify-content: center;
   align-items: center;
+  white-space: nowrap;
   text-align: center;
   width: max-content;
   border-radius: 0;

--- a/src/base/_typography.scss
+++ b/src/base/_typography.scss
@@ -12,7 +12,8 @@ h6 {
   font-weight: 600;
 }
 
-h1,.H1 {
+h1,
+.H1 {
   font-weight: 400;
   font-size: 4em;
   line-height: 105%;
@@ -22,7 +23,8 @@ h1,.H1 {
   }
 }
 
-h2,.H2{
+h2,
+.H2 {
   font-size: 2em;
 
   @media (min-width: $desktop) {
@@ -30,22 +32,26 @@ h2,.H2{
   }
 }
 
-h3,.H3{
+h3,
+.H3 {
   font-size: 2.25rem;
   line-height: 2.6875rem;
 }
 
-h4,.H4{
+h4,
+.H4 {
   line-height: 2rem;
   font-size: 2.625rem;
 }
 
-h5,.H5{
+h5,
+.H5 {
   line-height: 2.25rem;
   font-size: 1.5rem;
 }
 
-h6,.H6 {
+h6,
+.H6 {
   line-height: 1.875rem;
   font-size: 1.25rem;
 }
@@ -67,7 +73,6 @@ pre {
 ol,
 ul {
   margin: 20px 0 20px 30px;
-
 }
 
 ol {
@@ -91,4 +96,3 @@ strong {
 em {
   font-style: italic;
 }
-

--- a/src/components/collections-grid/collections-grid.module.scss
+++ b/src/components/collections-grid/collections-grid.module.scss
@@ -101,32 +101,6 @@
   }
 }
 
-.shopButton {
-  min-width: 200px;
-  cursor: pointer;
-  height: 45px;
-  background: $color-orange;
-  font-family: $font-secondary;
-  font-weight: 600;
-  color: #fff;
-  text-transform: uppercase;
-  line-height: 108%;
-  letter-spacing: 0.125em;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin: 0 auto;
-  @media (min-width: $tablet) {
-    min-width: 296px;
-    height: 60px;
-  }
-
-  .btnContent {
-    display: flex;
-    align-items: center;
-  }
-}
-
 .horizontalLine {
   width: 100%;
   height: 1px;

--- a/src/components/collections-grid/collections-grid.module.scss
+++ b/src/components/collections-grid/collections-grid.module.scss
@@ -107,3 +107,7 @@
   background-color: $color-orange;
   margin: 20px 0;
 }
+
+.button {
+  font-size: 1rem;
+}

--- a/src/components/collections-grid/shop-by-room.js
+++ b/src/components/collections-grid/shop-by-room.js
@@ -6,7 +6,13 @@ import { BiArrowBack } from 'react-icons/bi'
 
 import * as sty from './collections-grid.module.scss'
 
-export const ShopByRoom = ({ gallery, header, subheader, btnText }) => {
+export const ShopByRoom = ({
+  gallery,
+  header,
+  subheader,
+  btnText,
+  btnLink,
+}) => {
   return (
     <div className={sty.ShopByRoom}>
       <div className={sty.headerText}>
@@ -35,7 +41,7 @@ export const ShopByRoom = ({ gallery, header, subheader, btnText }) => {
       <div className={sty.buttonArea}>
         <div className={sty.horizontalLine}></div>
         <div>
-          <PrismicLink className="BtnPrimary" href="/">
+          <PrismicLink className="BtnPrimary" href={btnLink}>
             <PrismicRichText field={btnText?.richText}></PrismicRichText>
             <BiArrowBack
               size={18}

--- a/src/components/collections-grid/shop-by-room.js
+++ b/src/components/collections-grid/shop-by-room.js
@@ -34,15 +34,15 @@ export const ShopByRoom = ({ gallery, header, subheader, btnText }) => {
       </div>
       <div className={sty.buttonArea}>
         <div className={sty.horizontalLine}></div>
-        <button className={sty.shopButton}>
-          <span className={sty.btnContent}>
+        <div>
+          <PrismicLink className="BtnPrimary" href="/">
             <PrismicRichText field={btnText?.richText}></PrismicRichText>
             <BiArrowBack
               size={18}
               style={{ transform: 'scaleX(-1)', marginLeft: '0.5em' }}
             />
-          </span>
-        </button>
+          </PrismicLink>
+        </div>
         <div className={sty.horizontalLine}></div>
       </div>
     </div>

--- a/src/components/collections-grid/shop-by-room.js
+++ b/src/components/collections-grid/shop-by-room.js
@@ -40,15 +40,15 @@ export const ShopByRoom = ({
       </div>
       <div className={sty.buttonArea}>
         <div className={sty.horizontalLine}></div>
-        <div>
-          <PrismicLink className="BtnPrimary" href={btnLink}>
-            <PrismicRichText field={btnText?.richText}></PrismicRichText>
-            <BiArrowBack
-              size={18}
-              style={{ transform: 'scaleX(-1)', marginLeft: '0.5em' }}
-            />
-          </PrismicLink>
-        </div>
+
+        <PrismicLink className="BtnPrimary" href={btnLink}>
+          <PrismicRichText field={btnText?.richText}></PrismicRichText>
+          <BiArrowBack
+            size={18}
+            style={{ transform: 'scaleX(-1)', marginLeft: '0.5em' }}
+          />
+        </PrismicLink>
+
         <div className={sty.horizontalLine}></div>
       </div>
     </div>

--- a/src/components/slices/faculty-grid.js
+++ b/src/components/slices/faculty-grid.js
@@ -39,15 +39,13 @@ export const FacultyGrid = ({ slice }) => {
       </div>
       <div className={sty.buttonArea}>
         <div className={sty.horizontalLine}></div>
-        <div>
-          <PrismicLink className="BtnPrimary" href="/">
-            {slice.primary.button_text}
-            <BiArrowBack
-              size={18}
-              style={{ transform: 'scaleX(-1)', marginLeft: '0.5em' }}
-            />
-          </PrismicLink>
-        </div>
+        <PrismicLink className="BtnPrimary" href="/">
+          {slice.primary.button_text}
+          <BiArrowBack
+            size={18}
+            style={{ transform: 'scaleX(-1)', marginLeft: '0.5em' }}
+          />
+        </PrismicLink>
         <div className={sty.horizontalLine}></div>
       </div>
     </section>

--- a/src/components/slices/faculty-grid.js
+++ b/src/components/slices/faculty-grid.js
@@ -3,7 +3,7 @@ import { graphql } from 'gatsby'
 import { GatsbyImage } from 'gatsby-plugin-image'
 import { Container } from '../Components'
 import * as sty from './faculty-grid.module.scss'
-import { PrismicRichText } from '@prismicio/react'
+import { PrismicRichText, PrismicLink } from '@prismicio/react'
 import { BiArrowBack } from 'react-icons/bi'
 
 export const FacultyGrid = ({ slice }) => {
@@ -39,19 +39,15 @@ export const FacultyGrid = ({ slice }) => {
       </div>
       <div className={sty.buttonArea}>
         <div className={sty.horizontalLine}></div>
-
-        <button className={sty.viewWorkButton}>
-          <span className={sty.btnContent}>
+        <div>
+          <PrismicLink className="BtnPrimary" href="/">
             {slice.primary.button_text}
             <BiArrowBack
               size={18}
-              style={{
-                transform: 'scaleX(-1)',
-                marginLeft: '0.5em',
-              }}
+              style={{ transform: 'scaleX(-1)', marginLeft: '0.5em' }}
             />
-          </span>
-        </button>
+          </PrismicLink>
+        </div>
         <div className={sty.horizontalLine}></div>
       </div>
     </section>

--- a/src/components/slices/faculty-grid.module.scss
+++ b/src/components/slices/faculty-grid.module.scss
@@ -144,30 +144,6 @@
   }
 }
 
-.viewWorkButton {
-  min-width: 240px;
-  height: 45px;
-  background: $color-orange;
-  font-family: $font-secondary;
-  font-weight: 600;
-  color: $color-white;
-  text-transform: uppercase;
-  line-height: 108%;
-  letter-spacing: 0.125em;
-  display: block;
-  margin: 0 auto;
-  @media (min-width: $tablet) {
-    min-width: 296px;
-    height: 65px;
-  }
-}
-
-.btnContent {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
 .horizontalLine {
   width: 100%;
   height: 1px;

--- a/src/components/slices/hero-banner.js
+++ b/src/components/slices/hero-banner.js
@@ -2,21 +2,19 @@ import * as React from 'react'
 import { graphql } from 'gatsby'
 import { GatsbyImage, StaticImage } from 'gatsby-plugin-image'
 import { PrismicRichText, PrismicLink } from '@prismicio/react'
-import {
-  BiArrowBack
-} from 'react-icons/bi'
+import { BiArrowBack } from 'react-icons/bi'
 import { useLocation } from '@reach/router'
 
 import * as sty from './hero-banner.module.scss'
 
 export const HeroBanner = ({ slice }) => {
-  const location = useLocation(); // Use useLocation hook to get location object
-  const [local, setLocal] = React.useState('/'); // Initialize local state
+  const location = useLocation() // Use useLocation hook to get location object
+  const [local, setLocal] = React.useState('/') // Initialize local state
 
   React.useEffect(() => {
     // Set local state based on the current pathname
-    setLocal(location.pathname);
-  }, [location.pathname]); // Dependency array, effect runs only when pathname changes
+    setLocal(location.pathname)
+  }, [location.pathname]) // Dependency array, effect runs only when pathname changes
 
   return (
     <section className={sty.heroBanner} style={{ paddingBottom: 0 }}>
@@ -28,14 +26,21 @@ export const HeroBanner = ({ slice }) => {
               width={378}
               height={182}
               layout="constrained"
-              />
-            </a>
+            />
+          </a>
         </div>
         <div className={`${sty.copyWrap} ${sty.homeCopy}`}>
           <PrismicRichText field={slice.primary.page_title?.richText} />
           {slice.primary.callout_link && (
-            <PrismicLink href={slice.primary.callout_link.url} className={`BtnPrimary ${sty.HeroBtn}`}>
-              {slice.primary.callout_label} <BiArrowBack size={18} style={{transform: 'scaleX(-1)', marginLeft: '0.5em'}} />
+            <PrismicLink
+              href={slice.primary.callout_link.url}
+              className={`BtnPrimary ${sty.HeroBtn}`}
+            >
+              {slice.primary.callout_label}{' '}
+              <BiArrowBack
+                size={18}
+                style={{ transform: 'scaleX(-1)', marginLeft: '0.5em' }}
+              />
             </PrismicLink>
           )}
         </div>
@@ -44,10 +49,10 @@ export const HeroBanner = ({ slice }) => {
             className={sty.heroImage}
             image={slice.primary.hero_banner_image?.gatsbyImageData}
             alt={slice.primary.hero_banner_image?.alt || ''}
-            objectFit='cover'
-            objectPosition='50% 50%'
-            loading='eager'
-            />
+            objectFit="cover"
+            objectPosition="50% 50%"
+            loading="eager"
+          />
         )}
       </div>
     </section>

--- a/src/components/slices/hero-banner.module.scss
+++ b/src/components/slices/hero-banner.module.scss
@@ -112,7 +112,4 @@
 .HeroBtn {
   margin-top: 1em;
   margin: 1em auto 0 auto;
-  @media (max-width: $tablet) {
-    font-size: 0.875em !important;
-  }
 }

--- a/src/components/slices/press-list.js
+++ b/src/components/slices/press-list.js
@@ -2,8 +2,8 @@ import * as React from 'react'
 import { graphql } from 'gatsby'
 import { GatsbyImage, StaticImage } from 'gatsby-plugin-image'
 import { PrismicRichText, PrismicLink } from '@prismicio/react'
-import { FaLongArrowAltRight } from 'react-icons/fa'
 import { Container, Button } from '../Components'
+import { BiArrowBack } from 'react-icons/bi'
 
 import * as sty from './press-list.module.scss'
 
@@ -28,7 +28,10 @@ export const PressList = ({ slice }) => {
                 <PrismicLink href={item.article_link?.url}>
                   <Button>
                     Read More &nbsp;
-                    <FaLongArrowAltRight />
+                    <BiArrowBack
+                      size={18}
+                      style={{ transform: 'scaleX(-1)', marginLeft: '0.5em' }}
+                    />
                   </Button>
                 </PrismicLink>
               </div>

--- a/src/templates/home.js
+++ b/src/templates/home.js
@@ -27,6 +27,7 @@ const HomeTemplate = ({ data }) => {
   const shopByRoomHeader = node.shop_by_room_header
   const shopByRoomSubHeader = node.shop_by_room_sub_header
   const shopByRoomBtnText = node.shop_by_room_btn_text
+  const shopByRoomBtnLink = node.shop_by_room_btn_link
 
   const instaHeader = node.instagram_header
   const viewLabel = node.view_media_label
@@ -51,6 +52,7 @@ const HomeTemplate = ({ data }) => {
         header={shopByRoomHeader}
         subheader={shopByRoomSubHeader}
         btnText={shopByRoomBtnText}
+        btnLink={shopByRoomBtnLink}
       />
       <Testimonials
         testimonials={testimonials}
@@ -96,6 +98,9 @@ export const query = graphql`
         }
         shop_by_room_btn_text {
           richText
+        }
+        shop_by_room_btn_link {
+          url
         }
         shop_by_room_sub_header {
           richText


### PR DESCRIPTION
**Build-989 Button QA Fix**
https://app.clickup.com/t/9009201449/BUILD-993

**Changes**
Altered the BtnPrimary class to handle all button styling
Replaced buttons that were not setup with PrismicLink and separate css classes to use PrismicLink and the BtnPrimary class 
Replaced button arrow icons for the press list buttons on [http://localhost:8000/in-the-press](http://localhost:8000/in-the-press)
**Testing**
Pull PR branch
`yarn install`
`yarn start`
View the buttons on the homepage, about page etc. They should all be the same now. They should also now have the black border on hover unlike before.

**Notes**
- I have it so its 20px 40px on the button label, so they aren't all the same width, it's dependent on the length of the text. If it should be a set width for all buttons I can change that quick. 
- The only button that isn't the same currently is on the homepage in the shop by room section, the shop all button's label is 22.5px. The BtnPrimary class gives the labels 1.25rem but something is changing the base on that one and making it bigger and I can't find it. 
- Think I got all the buttons but lmk if I missed any