### PR TITLE
Build-1049 About Page Column Callout slice

### DIFF
--- a/src/components/slices/column-callout.js
+++ b/src/components/slices/column-callout.js
@@ -15,7 +15,7 @@ export const ColumnCallout = ({ slice }) => {
         </div>
         <div className={sty.columns}>
           {slice.items.map((item) => (
-            <div className={sty.employeeCard}>
+            <div className={sty.columnContent}>
               <div className={sty.imageWrap}>
                 <GatsbyImage
                   image={item.image?.gatsbyImageData}
@@ -24,12 +24,12 @@ export const ColumnCallout = ({ slice }) => {
                 />
               </div>
               <div className={sty.itemText}>
-                <p>{item.title}</p>
+                <p className={sty.itemTitle}>{item.title}</p>
                 <PrismicRichText field={item.description.richText} />
-                <PrismicLink href={item.link} className="BtnPrimary">
-                  {item.link_label}
-                </PrismicLink>
               </div>
+              <PrismicLink href={item.link} className="BtnPrimary">
+                {item.link_label}
+              </PrismicLink>
             </div>
           ))}
         </div>

--- a/src/components/slices/column-callout.js
+++ b/src/components/slices/column-callout.js
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { graphql } from 'gatsby'
-import { PrismicRichText } from '@prismicio/react'
-
+import { PrismicRichText, PrismicLink } from '@prismicio/react'
+import { GatsbyImage } from 'gatsby-plugin-image'
 import * as sty from './column-callout.module.scss'
 
 export const ColumnCallout = ({ slice }) => {
@@ -10,6 +10,26 @@ export const ColumnCallout = ({ slice }) => {
       <div className={sty.copyWrap}>
         <p className={sty.subtitle}>{slice.primary.subtitle}</p>
         <PrismicRichText field={slice.primary.title.richText} />
+      </div>
+      <div className={sty.columns}>
+        {slice.items.map((item) => (
+          <div className={sty.employeeCard}>
+            <div className={sty.imageWrap}>
+              <GatsbyImage
+                image={item.image?.gatsbyImageData}
+                alt={item.image?.alt || ''}
+                className={sty.image}
+              />
+            </div>
+            <div className={sty.itemText}>
+              <p>{item.title}</p>
+              <PrismicRichText field={item.description.richText} />
+              <PrismicLink href={item.link} className="BtnPrimary">
+                {item.link_label}
+              </PrismicLink>
+            </div>
+          </div>
+        ))}
       </div>
     </section>
   )

--- a/src/components/slices/column-callout.js
+++ b/src/components/slices/column-callout.js
@@ -3,34 +3,37 @@ import { graphql } from 'gatsby'
 import { PrismicRichText, PrismicLink } from '@prismicio/react'
 import { GatsbyImage } from 'gatsby-plugin-image'
 import * as sty from './column-callout.module.scss'
+import { Container } from '../Components'
 
 export const ColumnCallout = ({ slice }) => {
   return (
     <section className={sty.ColumnCallout}>
-      <div className={sty.copyWrap}>
-        <p className={sty.subtitle}>{slice.primary.subtitle}</p>
-        <PrismicRichText field={slice.primary.title.richText} />
-      </div>
-      <div className={sty.columns}>
-        {slice.items.map((item) => (
-          <div className={sty.employeeCard}>
-            <div className={sty.imageWrap}>
-              <GatsbyImage
-                image={item.image?.gatsbyImageData}
-                alt={item.image?.alt || ''}
-                className={sty.image}
-              />
+      <Container>
+        <div className={sty.copyWrap}>
+          <p className={sty.subtitle}>{slice.primary.subtitle}</p>
+          <PrismicRichText field={slice.primary.title.richText} />
+        </div>
+        <div className={sty.columns}>
+          {slice.items.map((item) => (
+            <div className={sty.employeeCard}>
+              <div className={sty.imageWrap}>
+                <GatsbyImage
+                  image={item.image?.gatsbyImageData}
+                  alt={item.image?.alt || ''}
+                  className={sty.image}
+                />
+              </div>
+              <div className={sty.itemText}>
+                <p>{item.title}</p>
+                <PrismicRichText field={item.description.richText} />
+                <PrismicLink href={item.link} className="BtnPrimary">
+                  {item.link_label}
+                </PrismicLink>
+              </div>
             </div>
-            <div className={sty.itemText}>
-              <p>{item.title}</p>
-              <PrismicRichText field={item.description.richText} />
-              <PrismicLink href={item.link} className="BtnPrimary">
-                {item.link_label}
-              </PrismicLink>
-            </div>
-          </div>
-        ))}
-      </div>
+          ))}
+        </div>
+      </Container>
     </section>
   )
 }
@@ -52,6 +55,10 @@ export const query = graphql`
       link_label
       link {
         url
+      }
+      image {
+        gatsbyImageData
+        alt
       }
     }
   }

--- a/src/components/slices/column-callout.js
+++ b/src/components/slices/column-callout.js
@@ -1,0 +1,31 @@
+import * as React from 'react'
+import { graphql } from 'gatsby'
+import { PrismicRichText } from '@prismicio/react'
+
+import * as sty from './column-callout.module.scss'
+
+export const ColumnCallout = ({ slice }) => {
+  return <div></div>
+}
+
+export const query = graphql`
+  fragment PageDataBodyColumnCallout on PrismicPageDataBodyColumnCallout {
+    id
+    primary {
+      subtitle
+      title {
+        richText
+      }
+    }
+    items {
+      title
+      description {
+        richText
+      }
+      link_label
+      link {
+        url
+      }
+    }
+  }
+`

--- a/src/components/slices/column-callout.js
+++ b/src/components/slices/column-callout.js
@@ -5,7 +5,14 @@ import { PrismicRichText } from '@prismicio/react'
 import * as sty from './column-callout.module.scss'
 
 export const ColumnCallout = ({ slice }) => {
-  return <div></div>
+  return (
+    <section className={sty.ColumnCallout}>
+      <div className={sty.copyWrap}>
+        <p className={sty.subtitle}>{slice.primary.subtitle}</p>
+        <PrismicRichText field={slice.primary.title.richText} />
+      </div>
+    </section>
+  )
 }
 
 export const query = graphql`

--- a/src/components/slices/column-callout.module.scss
+++ b/src/components/slices/column-callout.module.scss
@@ -47,6 +47,7 @@
       padding: 15px;
       @media (min-width: $tablet) {
         padding: 25px;
+        width: 100%;
       }
     }
 
@@ -67,6 +68,7 @@
       display: flex;
       flex-direction: column;
       align-items: center;
+      flex: 1 1 0;
       gap: 25px;
       @media (min-width: $tablet) {
         gap: 40px;

--- a/src/components/slices/column-callout.module.scss
+++ b/src/components/slices/column-callout.module.scss
@@ -1,0 +1,8 @@
+.ColumnCallout {
+  .copyWrap {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+  }
+}

--- a/src/components/slices/column-callout.module.scss
+++ b/src/components/slices/column-callout.module.scss
@@ -30,7 +30,7 @@
     text-align: center;
     gap: 45px;
 
-    @media (min-width: $tablet) {
+    @media (min-width: $mobile) {
       flex-direction: row;
       gap: 15px;
     }

--- a/src/components/slices/column-callout.module.scss
+++ b/src/components/slices/column-callout.module.scss
@@ -16,4 +16,17 @@
       font-weight: 600;
     }
   }
+
+  .columns {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    text-align: center;
+  }
+
+  .itemText {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
 }

--- a/src/components/slices/column-callout.module.scss
+++ b/src/components/slices/column-callout.module.scss
@@ -78,6 +78,10 @@
     display: flex;
     flex-direction: column;
     align-items: center;
+    padding: 0 5px;
+    @media (min-width: $tablet) {
+      padding: 0 15px;
+    }
 
     .itemTitle {
       font-family: $font-secondary;

--- a/src/components/slices/column-callout.module.scss
+++ b/src/components/slices/column-callout.module.scss
@@ -22,6 +22,36 @@
     flex-direction: row;
     justify-content: center;
     text-align: center;
+    gap: 10px;
+
+    .imageWrap {
+      width: 100%;
+      aspect-ratio: 1/1;
+      position: relative;
+      overflow: hidden;
+      background: $color-sagelt;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+
+      padding: 15px;
+      @media (min-width: $tablet) {
+        padding: 25px;
+      }
+    }
+
+    .image {
+      width: 100%;
+      height: 100%;
+      border-radius: 99em;
+      display: block;
+      margin: 0 auto;
+      border: 10px solid $color-white;
+      @media (min-width: $tablet) {
+        max-width: 400px;
+        max-height: 400px;
+      }
+    }
   }
 
   .itemText {

--- a/src/components/slices/column-callout.module.scss
+++ b/src/components/slices/column-callout.module.scss
@@ -1,8 +1,19 @@
+@import '../../base/module';
 .ColumnCallout {
   .copyWrap {
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
+    font-size: 2.75rem;
+    font-family: $font-header;
+    font-weight: 400;
+
+    .subtitle {
+      font-size: 1.5rem;
+      font-family: $font-secondary;
+      text-transform: uppercase;
+      font-weight: 600;
+    }
   }
 }

--- a/src/components/slices/column-callout.module.scss
+++ b/src/components/slices/column-callout.module.scss
@@ -5,24 +5,35 @@
     flex-direction: column;
     justify-content: center;
     align-items: center;
+    text-align: center;
     font-size: 2.75rem;
     font-family: $font-header;
     font-weight: 400;
+    margin-bottom: 15px;
+    @media (min-width: $tablet) {
+      margin-bottom: 30px;
+    }
 
     .subtitle {
       font-size: 1.5rem;
       font-family: $font-secondary;
       text-transform: uppercase;
       font-weight: 600;
+      letter-spacing: 0.13em;
     }
   }
 
   .columns {
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
     justify-content: center;
     text-align: center;
-    gap: 10px;
+    gap: 45px;
+
+    @media (min-width: $tablet) {
+      flex-direction: row;
+      gap: 15px;
+    }
 
     .imageWrap {
       width: 100%;
@@ -33,7 +44,6 @@
       display: flex;
       justify-content: center;
       align-items: center;
-
       padding: 15px;
       @media (min-width: $tablet) {
         padding: 25px;
@@ -52,11 +62,30 @@
         max-height: 400px;
       }
     }
+
+    .columnContent {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 25px;
+      @media (min-width: $tablet) {
+        gap: 40px;
+      }
+    }
   }
 
   .itemText {
     display: flex;
     flex-direction: column;
     align-items: center;
+
+    .itemTitle {
+      font-family: $font-secondary;
+      font-size: 1.5rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.13em;
+      margin-bottom: 10px;
+    }
   }
 }

--- a/src/components/slices/index.js
+++ b/src/components/slices/index.js
@@ -8,6 +8,7 @@ import { PressList } from './press-list'
 import { HeroBanner } from './hero-banner'
 import { IntroDescription } from './intro-description'
 import { ColorPicker } from './color-picker'
+import { ColumnCallout } from './column-callout'
 
 export const components = {
   text_image: TextImage,
@@ -20,4 +21,5 @@ export const components = {
   hero_banner: HeroBanner,
   intro_description: IntroDescription,
   color_picker: ColorPicker,
+  column_callout: ColumnCallout,
 }

--- a/src/templates/page.js
+++ b/src/templates/page.js
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { graphql } from 'gatsby'
 import { withPrismicPreview } from 'gatsby-plugin-prismic-previews'
 import { SliceZone, PrismicRichText, PrismicLink } from '@prismicio/react'
-import { Container } from "../components/Components"
+import { Container } from '../components/Components'
 import { Layout } from '../components/Layout'
 import { components } from '../components/slices'
 
@@ -24,14 +24,18 @@ const PageTemplate = ({ data }) => {
 
   return (
     <Layout menu={menu.data} activeDocMeta={activeDoc}>
-      <SliceZone slices={page.body} components={components} context={{lang: lang}}/>
+      <SliceZone
+        slices={page.body}
+        components={components}
+        context={{ lang: lang }}
+      />
     </Layout>
   )
 }
 
 export const query = graphql`
   query pageQuery($id: String, $lang: String) {
-    prismicPage(id: { eq: $id },lang: { eq: $lang }) {
+    prismicPage(id: { eq: $id }, lang: { eq: $lang }) {
       _previewable
       alternate_languages {
         uid
@@ -57,6 +61,7 @@ export const query = graphql`
           ...PageDataBodyFacultyGrid
           ...PageDataBodyAwardsGallery
           ...PageDataBodyPressList
+          ...PageDataBodyColumnCallout
         }
       }
     }
@@ -67,4 +72,4 @@ export const query = graphql`
   }
 `
 
-export default withPrismicPreview(PageTemplate);
+export default withPrismicPreview(PageTemplate)


### PR DESCRIPTION
**Build-1049 About Page Column Callout slice**
https://app.clickup.com/t/9009201449/BUILD-1049

**Changes**
Added the slice this was missing from the about page
![image](https://github.com/user-attachments/assets/f0c901dd-3303-4467-8d99-8c957eb73cdf)

**Testing**
Pull PR branch
`yarn install`
`yarn start`
Go to http://localhost:8000/about
View the slice and test it for mobile
[Figma Design](https://www.figma.com/design/VUxtgRSA7pJLgdp50o0N7y/Design-Studio?node-id=3855-5674&node-type=frame&m=dev)

**Slice**
![image](https://github.com/user-attachments/assets/ba05c14a-186d-4919-ba48-3e1165ecf307)


**Notes**
I can't get them to shrink evenly on tablet for some reason
![image](https://github.com/user-attachments/assets/4c5a3dd1-df00-4350-90bc-0387b0dece17)
