### PR TITLE
[BUILD-1059] - Print Wishlist

### DIFF
--- a/src/base/_base.scss
+++ b/src/base/_base.scss
@@ -8,7 +8,23 @@ html {
   padding: 0;
   border: 0;
   font-size: 100%;
+  -webkit-print-color-adjust: exact !important;
+  color-adjust: exact !important;
+  print-color-adjust: exact !important;
 }
+
+@media print {
+  .skip_button {
+    display: none;
+  }
+  @page {
+    margin-left: 0.8in;
+    margin-right: 0.8in;
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+}
+
 ::selection {
   background: $color-hl; /* WebKit/Blink Browsers */
 }

--- a/src/pages/cart.js
+++ b/src/pages/cart.js
@@ -126,7 +126,7 @@ export default function CartPage({ data }) {
                 </button>
               ) : (
                 <button
-                  onClick={handleCheckout}
+                  onClick={()=> window.print()}
                   disabled={loading}
                   className="BtnPrimary"
                   style={{

--- a/src/pages/cart.js
+++ b/src/pages/cart.js
@@ -133,7 +133,7 @@ export default function CartPage({ data }) {
                     marginTop: 40,
                   }}
                 >
-                  Print or Download PDF
+                  Print PDF
                 </button>
               )}
             </>


### PR DESCRIPTION
# Description
[BUILD-1059](https://app.clickup.com/t/9009201449/BUILD-1059)


In this PR, I changed the button in the shopping cart. When the user selects "Turks ...", they are unable to purchase the item, it only allows the user to print a wishlist instead. 

# To run
1. Go to branch
2. `yarn install`
3. `yarn start`
4. Navigate to a shopping item. http://localhost:8000/product/test-product-for-web
5. Add items to your cart. Go to the checkout http://localhost:8000/cart
8. In the checkout, if "Cayman Islands" is selected, check to see if you could navigate to checkout. The button text should say "Checkout"
9. When "Turks... " is selected, check to see if all relevant text turns into "Wishlist" or similar. No mentions of shopping cart should be shown. 
10. With "Turks..." selected, click on the download PDF button. It should allow you to print a screen-friendly wishlist of the items you have saved. 

# Images

Cayman Islands:
<img width="1504" alt="image" src="https://github.com/user-attachments/assets/52505be1-9162-4c35-b1bb-b32218efeceb">


Turks... : 
<img width="1502" alt="image" src="https://github.com/user-attachments/assets/f3e0bb63-d227-4e17-80c6-4594c598d81a">

<img width="1496" alt="image" src="https://github.com/user-attachments/assets/a041fd76-51bb-405a-9747-126d796a9050">




