### PR TITLE
[BUILD-1379-] About Page Links Fix

### DIFF
--- a/src/components/slices/column-callout.js
+++ b/src/components/slices/column-callout.js
@@ -27,7 +27,7 @@ export const ColumnCallout = ({ slice }) => {
                 <p className={sty.itemTitle}>{item.title}</p>
                 <PrismicRichText field={item.description.richText} />
               </div>
-              <PrismicLink href={item.link} className="BtnPrimary">
+              <PrismicLink href={item.link?.url} className="BtnPrimary">
                 {item.link_label}
               </PrismicLink>
             </div>


### PR DESCRIPTION
**[BUILD-1379-] About Page Links Fix**
https://app.clickup.com/t/9009201449/BUILD-1379

**Changes**
Just added `?.url` to where it was missing to fix the links

**Testing**
Pull PR branch
`yarn install`
`yarn start`
Go to http://localhost:8000/about
Click on the buttons in the "our services" section, make sure they take you somewhere on the site
![image](https://github.com/user-attachments/assets/a52768c7-7256-41b8-ae1b-880a58c82e1b)
