### PR TITLE
[BUILD-1380] Font/Text Cleanup

### DIFF
--- a/src/base/_base.scss
+++ b/src/base/_base.scss
@@ -100,6 +100,11 @@ span.BtnSecondary {
   &:hover {
     border-color: $color-black;
   }
+
+  @media (max-width: 768px) {
+    padding: 1rem 2rem;
+    font-size: 1.125rem;
+  }
 }
 .BtnSecondary {
   @extend .Btn;

--- a/src/base/_typography.scss
+++ b/src/base/_typography.scss
@@ -26,9 +26,11 @@ h1,
 h2,
 .H2 {
   font-size: 2em;
+  font-style: italic;
+  font-weight: 400;
 
   @media (min-width: $desktop) {
-    font-size: 2.625em;
+    font-size: 3.125em;
   }
 }
 

--- a/src/components/_homepage/testimonials.module.scss
+++ b/src/components/_homepage/testimonials.module.scss
@@ -49,19 +49,22 @@
     font-family: $font-secondary;
 
     line-height: 1.62rem;
-    letter-spacing: 0.15rem;
   }
 
   .quotesHead p {
     text-transform: uppercase;
     font-weight: 600;
+    letter-spacing: 0.13em;
   }
 
   .quotesHead h2 {
     font-family: $font-header;
-    font-size: 3.25em;
+    font-size: 2.1em;
     font-style: italic;
     font-weight: 400;
+    @media (min-width: $tablet) {
+      font-size: 3.25em;
+    }
   }
 
   .quoteWrap {
@@ -107,7 +110,7 @@
     font-family: $font-secondary;
     font-weight: 600;
     text-align: center;
-    letter-spacing: 0.04em;
+    letter-spacing: 0.13em;
     color: $color-black;
     text-align: left;
     background-color: $color-darkgreen;

--- a/src/components/_project/project-hero.module.scss
+++ b/src/components/_project/project-hero.module.scss
@@ -17,10 +17,13 @@
 
   .tag {
     font-weight: 600;
-    font-size: 1.5rem;
+    font-size: 1.25rem;
     line-height: 1.75em;
     text-transform: uppercase;
     font-family: $font-secondary;
     letter-spacing: 0.13em;
+    @media (min-width: $mobile) {
+      font-size: 1.5rem;
+    }
   }
 }

--- a/src/components/collections-grid/collections-grid.module.scss
+++ b/src/components/collections-grid/collections-grid.module.scss
@@ -59,7 +59,7 @@
         text-transform: uppercase;
         line-height: 108%;
         letter-spacing: 0.14em;
-        @media (min-width: $tablet) {
+        @media (min-width: $mobile) {
           font-size: 1.5em;
           margin-top: 40px;
         }

--- a/src/components/collections-grid/collections-grid.module.scss
+++ b/src/components/collections-grid/collections-grid.module.scss
@@ -79,10 +79,13 @@
   font-family: $font-secondary;
   text-transform: uppercase;
   font-weight: 600;
-  font-size: 1.5em;
+  font-size: 1.25em;
   line-height: 108%;
   letter-spacing: 0.14em;
   margin-bottom: 20px;
+  @media (min-width: $mobile) {
+    font-size: 1.5em;
+  }
 }
 
 .headerText h2 {

--- a/src/components/slices/catalog-grid.module.scss
+++ b/src/components/slices/catalog-grid.module.scss
@@ -13,6 +13,7 @@
       font-family: $font-secondary;
       letter-spacing: 0.13em;
       margin-bottom: 5px;
+      font-size: 1.5rem;
     }
   }
 

--- a/src/components/slices/catalog-grid.module.scss
+++ b/src/components/slices/catalog-grid.module.scss
@@ -13,7 +13,10 @@
       font-family: $font-secondary;
       letter-spacing: 0.13em;
       margin-bottom: 5px;
-      font-size: 1.5rem;
+      font-size: 1.25rem;
+      @media (min-width: $tablet) {
+        font-size: 1.5rem;
+      }
     }
   }
 
@@ -92,7 +95,7 @@
       }
 
       @media (max-width: $mobile) {
-        font-size: 0.775rem;
+        font-size: 1rem;
       }
     }
     @media (max-width: $tablet) {

--- a/src/components/slices/color-picker.module.scss
+++ b/src/components/slices/color-picker.module.scss
@@ -30,12 +30,12 @@
 .titleText {
   p {
     font-family: $font-secondary;
-    font-size: 1.15em;
+    font-size: 1.25em;
     text-transform: uppercase;
     font-weight: 600;
     letter-spacing: 0.13em;
     margin-bottom: 30px;
-    @media (min-width: $tablet) {
+    @media (min-width: $mobile) {
       font-size: 1.5em;
     }
   }

--- a/src/components/slices/column-callout.module.scss
+++ b/src/components/slices/column-callout.module.scss
@@ -13,11 +13,14 @@
     }
 
     .subtitle {
-      font-size: 1.5rem;
+      font-size: 1.25rem;
       font-family: $font-secondary;
       text-transform: uppercase;
       font-weight: 600;
       letter-spacing: 0.13em;
+      @media (min-width: $mobile) {
+        font-size: 1.5rem;
+      }
     }
   }
 
@@ -85,11 +88,14 @@
 
     .itemTitle {
       font-family: $font-secondary;
-      font-size: 1.5rem;
+      font-size: 1.25rem;
       font-weight: 600;
       text-transform: uppercase;
       letter-spacing: 0.13em;
       margin-bottom: 10px;
+      @media (min-width: $mobile) {
+        font-size: 1.5rem;
+      }
     }
   }
 }

--- a/src/components/slices/column-callout.module.scss
+++ b/src/components/slices/column-callout.module.scss
@@ -6,9 +6,7 @@
     justify-content: center;
     align-items: center;
     text-align: center;
-    font-size: 2.75rem;
-    font-family: $font-header;
-    font-weight: 400;
+
     margin-bottom: 15px;
     @media (min-width: $tablet) {
       margin-bottom: 30px;

--- a/src/components/slices/faculty-grid.module.scss
+++ b/src/components/slices/faculty-grid.module.scss
@@ -38,10 +38,8 @@
     margin: 0 auto;
     width: 100%;
     text-align: center;
-    font-size: 1em;
     @media (min-width: $tablet) {
       width: 60%;
-      font-size: 1.125em;
     }
   }
 
@@ -64,6 +62,7 @@
   text-transform: uppercase;
   font-family: $font-secondary;
   font-size: 1.25em;
+  letter-spacing: 0.13em;
   @media (min-width: $tablet) {
     font-size: 1.5em;
   }

--- a/src/components/slices/faculty-grid.module.scss
+++ b/src/components/slices/faculty-grid.module.scss
@@ -90,7 +90,7 @@
   display: block;
   margin-bottom: 16px;
   text-align: center;
-  @media (min-width: $tablet) {
+  @media (min-width: $mobile) {
     margin-bottom: 0px;
     font-size: 1.5em;
   }

--- a/src/components/slices/grid-hero.module.scss
+++ b/src/components/slices/grid-hero.module.scss
@@ -43,8 +43,11 @@
     p {
       font-family: $font-secondary;
       text-transform: uppercase;
-      font-size: 1.5rem;
+      font-size: 1.25rem;
       letter-spacing: 0.13em;
+      @media (min-width: $mobile) {
+        font-size: 1.5rem;
+      }
     }
     h2 {
       font-weight: 400;

--- a/src/components/slices/hero-banner.module.scss
+++ b/src/components/slices/hero-banner.module.scss
@@ -101,24 +101,16 @@
   h1 {
     font-style: italic;
     text-transform: none;
-    font-size: 3.75rem;
+    font-size: 1.75rem;
+    margin-top: 10px;
     @media (min-width: $desktop) {
-      font-size: 5.3em;
+      font-size: 2.5em;
+      margin-top: 0;
     }
   }
 
   @media (min-width: $desktop) {
     font-size: 1.4rem;
-  }
-
-  em {
-    font-family: $font-header;
-    text-transform: none;
-    font-size: 2em;
-    display: inline-block;
-    margin-top: -0.5em;
-    margin-left: 0.5em;
-    vertical-align: middle;
   }
 }
 

--- a/src/components/slices/hero-banner.module.scss
+++ b/src/components/slices/hero-banner.module.scss
@@ -114,7 +114,7 @@
   em {
     font-family: $font-header;
     text-transform: none;
-    font-size: 1.5em;
+    font-size: 2em;
     display: inline-block;
     margin-top: -0.5em;
     margin-left: 0.5em;

--- a/src/components/slices/project-grid.js
+++ b/src/components/slices/project-grid.js
@@ -55,7 +55,6 @@ export const ProjectGrid = ({ slice }) => {
                       className={sty.image}
                     />
                     <div className={sty.overlay}>
-                      <p>{prod.data.project_name}</p>
                       <PrismicLink
                         href={`/project/${prod.uid}`}
                         className={sty.link}

--- a/src/components/slices/project-grid.module.scss
+++ b/src/components/slices/project-grid.module.scss
@@ -6,7 +6,6 @@
   padding-top: 0;
   text-align: center;
   padding-top: 80px;
-
 }
 
 .grid {
@@ -32,7 +31,8 @@
     text-transform: uppercase;
     font-size: 1.5rem;
     margin-bottom: 8px;
-    font-weight: 600;
+    font-weight: 400;
+    letter-spacing: 0.13em;
     @media (max-width: $tablet) {
       font-size: 1.25rem;
     }

--- a/src/components/slices/project-grid.module.scss
+++ b/src/components/slices/project-grid.module.scss
@@ -132,7 +132,7 @@
     }
 
     @media (max-width: $mobile) {
-      font-size: 0.775rem;
+      font-size: 1rem;
     }
   }
   @media (max-width: $tablet) {


### PR DESCRIPTION
**[BUILD-1380] Font/Text Cleanup**
https://app.clickup.com/t/9009201449/BUILD-1380

**Changes**
Remove the Project name from the project grid overlay so its just "view project" now
![image](https://github.com/user-attachments/assets/65262315-9ce6-4d1e-89bd-0336cf3935f5)
![image](https://github.com/user-attachments/assets/784e87a8-e036-4314-b176-92b35eaa03c9)


Replaced all h2 text with h2s in Prismic (they were paragraphs) so they grab h2 styling now. Fixed any of the headers that were inconsistent from other factors. 
Redid mobile text across the board so text should be scaled down properly now and consistent
Fixed some letter spacing issues where it was missing or shouldn't be

**Testing**
Pull PR branch
`yarn install`
`yarn start`
Go to http://localhost:8000/
Take a scan through the pages on desktop and make sure all headers are consistent. Anything (h2) in Playfair font should be in italics now. 
Take a scan through the pages on mobile and make sure text is scaling down and consistent
Go to http://localhost:8000/portfolio and hover over a project, it should no longer have the project name and just "view project" 

**Notes**
I thiiiiink I got them all but if you find anywhere I missed a header or anything let me know!