### PR TITLE
[BUILD-1381] Center Text Slice Style

### DIFF
--- a/src/components/slices/centered-text.js
+++ b/src/components/slices/centered-text.js
@@ -6,7 +6,7 @@ import { Container } from '../Components'
 import * as sty from './centered-text.module.scss'
 
 export const CenteredText = ({ slice }) => {
-  const hasPalmImage = !!slice.primary.palm_image
+  const hasPalmImage = slice.primary.palm_image
 
   return (
     <section

--- a/src/components/slices/centered-text.js
+++ b/src/components/slices/centered-text.js
@@ -6,8 +6,12 @@ import { Container } from '../Components'
 import * as sty from './centered-text.module.scss'
 
 export const CenteredText = ({ slice }) => {
+  const hasPalmImage = !!slice.primary.palm_image
+
   return (
-    <section className={sty.CenteredText}>
+    <section
+      className={`${sty.CenteredText} ${hasPalmImage ? sty.palmImage : ''}`}
+    >
       <div className={sty.centerContainer}>
         <Container>
           <div className={sty.centerWrap}>
@@ -39,6 +43,7 @@ export const query = graphql`
       btn_link {
         url
       }
+      palm_image
     }
   }
 `

--- a/src/components/slices/centered-text.js
+++ b/src/components/slices/centered-text.js
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import { graphql } from 'gatsby'
-import { PrismicRichText } from '@prismicio/react'
-import { Container } from "../Components"
+import { PrismicLink, PrismicRichText } from '@prismicio/react'
+import { Container } from '../Components'
 
-import * as sty from './centered-text.module.scss';
+import * as sty from './centered-text.module.scss'
 
 export const CenteredText = ({ slice }) => {
   return (
@@ -11,7 +11,15 @@ export const CenteredText = ({ slice }) => {
       <div className={sty.centerContainer}>
         <Container>
           <div className={sty.centerWrap}>
-            <PrismicRichText field={slice.primary.richtext?.richText}/>
+            <p className={sty.title}>{slice.primary.text_title}</p>
+            <PrismicRichText field={slice.primary.richtext?.richText} />
+            <PrismicLink
+              href={slice.primary.btn_link?.url}
+              className="BtnPrimary"
+              title={slice.primary.btn_label}
+            >
+              {slice.primary.btn_label}
+            </PrismicLink>
           </div>
         </Container>
       </div>
@@ -25,6 +33,11 @@ export const query = graphql`
     primary {
       richtext {
         richText
+      }
+      text_title
+      btn_label
+      btn_link {
+        url
       }
     }
   }

--- a/src/components/slices/centered-text.module.scss
+++ b/src/components/slices/centered-text.module.scss
@@ -4,20 +4,19 @@
   padding: 0;
   overflow: hidden;
   position: relative;
-
   &.palmImage {
     &::before {
       content: '';
       position: absolute;
       left: -1%;
       bottom: 0;
-      z-index: 1;
-      width: 523px;
-      height: 680px;
+      z-index: 0;
+      width: 373px;
+      height: 520px;
       background-color: $color-sage;
       mask: url('../../images/palm.svg') no-repeat 100% 100%;
       mask-size: contain;
-
+      transform: translateY(-20%);
       @media (max-width: $tablet) {
         display: none;
       }

--- a/src/components/slices/centered-text.module.scss
+++ b/src/components/slices/centered-text.module.scss
@@ -3,9 +3,25 @@
 .CenteredText {
   padding: 0;
   overflow: hidden;
+  position: relative;
 
-  @media (min-width: $desktop) {
-    overflow: initial;
+  &.palmImage {
+    &::before {
+      content: '';
+      position: absolute;
+      left: -1%;
+      bottom: 0;
+      z-index: 1;
+      width: 523px;
+      height: 680px;
+      background-color: $color-sage;
+      mask: url('../../images/palm.svg') no-repeat 100% 100%;
+      mask-size: contain;
+
+      @media (max-width: $tablet) {
+        display: none;
+      }
+    }
   }
 }
 
@@ -25,6 +41,7 @@
     font-weight: 600;
     letter-spacing: 0.13em;
     font-size: 1.25rem;
+
     @media (min-width: $mobile) {
       font-size: 1.5rem;
     }

--- a/src/components/slices/centered-text.module.scss
+++ b/src/components/slices/centered-text.module.scss
@@ -4,6 +4,7 @@
   padding: 0;
   overflow: hidden;
   position: relative;
+  overflow: visible;
   &.palmImage {
     &::before {
       content: '';
@@ -11,12 +12,12 @@
       left: -1%;
       bottom: 0;
       z-index: 0;
-      width: 373px;
-      height: 520px;
+      width: 573px;
+      height: 720px;
       background-color: $color-sage;
       mask: url('../../images/palm.svg') no-repeat 100% 100%;
       mask-size: contain;
-      transform: translateY(-20%);
+      transform: translateY(10%);
       @media (max-width: $tablet) {
         display: none;
       }

--- a/src/components/slices/centered-text.module.scss
+++ b/src/components/slices/centered-text.module.scss
@@ -18,6 +18,17 @@
   align-items: center;
   gap: 36px;
   text-align: center;
+
+  .title {
+    text-transform: uppercase;
+    font-family: $font-secondary;
+    font-weight: 600;
+    letter-spacing: 0.13em;
+    font-size: 1.25rem;
+    @media (min-width: $mobile) {
+      font-size: 1.5rem;
+    }
+  }
 }
 
 .center-container {

--- a/src/components/slices/centered-text.module.scss
+++ b/src/components/slices/centered-text.module.scss
@@ -14,7 +14,7 @@
       z-index: 0;
       width: 573px;
       height: 720px;
-      background-color: $color-sage;
+      background-color: $color-sagelt;
       mask: url('../../images/palm.svg') no-repeat 100% 100%;
       mask-size: contain;
       transform: translateY(10%);


### PR DESCRIPTION
**[BUILD-1381] Center Text Slice Style**
https://app.clickup.com/t/9009201449/BUILD-1381

**Changes**
Styled the centered text slice

**Issues**
I don't fully understand how to properly do the palm so it scales down properly with the content and doesn't overlap it, would love some input here!

**Testing**
Go to PR branch
`yarn install`
`yarn start`
Go to http://localhost:8000/about
Compare to the [figma design](https://www.figma.com/design/VUxtgRSA7pJLgdp50o0N7y/Design-Studio?node-id=3855-5674&node-type=frame&t=wYzarlPwIACWSNqc-0)
Test responsiveness

![image](https://github.com/user-attachments/assets/b44a8fce-c8bf-42dd-88a7-e8692856cce5)

**Before Styling**
![image](https://github.com/user-attachments/assets/4f470461-8a24-4810-86c6-892f391ee9fc)
