### PR TITLE
[BUILD-1457] Cart Notification

### DIFF
--- a/src/components/cart-button.js
+++ b/src/components/cart-button.js
@@ -1,9 +1,19 @@
-import * as React from "react"
-import { Link } from "gatsby"
-import { BiShoppingBag } from "react-icons/bi"
-import { cartButton, badge } from "./cart-button.module.scss"
+import * as React from 'react'
+import { Link } from 'gatsby'
+import { BiShoppingBag } from 'react-icons/bi'
+import { cartButton, badge, animateBadge } from './cart-button.module.scss'
 
 export function CartButton({ quantity }) {
+  const [isAnimating, setIsAnimating] = React.useState(false)
+
+  React.useEffect(() => {
+    if (quantity > 0) {
+      setIsAnimating(true)
+      const timeout = setTimeout(() => setIsAnimating(false), 400)
+      return () => clearTimeout(timeout)
+    }
+  }, [quantity])
+
   return (
     <Link
       aria-label={`Shopping Cart with ${quantity} items`}
@@ -11,7 +21,11 @@ export function CartButton({ quantity }) {
       className={cartButton}
     >
       <BiShoppingBag size={25} />
-      {quantity > 0 && <div className={badge}>{quantity}</div>}
+      {quantity > 0 && (
+        <div className={`${badge} ${isAnimating ? animateBadge : ''}`}>
+          {quantity}
+        </div>
+      )}
     </Link>
   )
 }

--- a/src/components/cart-button.module.scss
+++ b/src/components/cart-button.module.scss
@@ -33,3 +33,19 @@
 
 .cartButton[aria-current='page'] {
 }
+
+.animateBadge {
+  animation: addToCart 0.3s ease-in-out;
+}
+
+@keyframes addToCart {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.3);
+  }
+  100% {
+    transform: scale(1);
+  }
+}

--- a/src/components/cart-button.module.scss
+++ b/src/components/cart-button.module.scss
@@ -10,14 +10,13 @@
 }
 
 .cartButton:hover {
-  
 }
 
 .badge {
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: $color-lightorange;
+  background-color: $color-orange;
   box-shadow: 0 0 0 2px white;
   color: black;
   font-size: 10px;
@@ -32,6 +31,5 @@
   box-sizing: border-box;
 }
 
-.cartButton[aria-current="page"] {
-  
+.cartButton[aria-current='page'] {
 }

--- a/src/components/cart-button.module.scss
+++ b/src/components/cart-button.module.scss
@@ -23,9 +23,9 @@
   font-weight: bold;
   border-radius: 50%;
   position: absolute;
-  bottom: -4px;
-  right: 4px;
-  min-width: 16px;
+  bottom: -12px;
+  right: -6px;
+  min-width: 28px;
   aspect-ratio: 1/1;
   padding: 0 8px;
   box-sizing: border-box;


### PR DESCRIPTION
**BUILD-1457 Cart Notification**
https://app.clickup.com/t/9009201449/BUILD-1457

**Changes**
Changed the cart badge color to orange
Added an animation when you add to cart
Increased the min width of the badge so when the cart quantity moves to double digits it doesn't cover the cart icon

**Testing**
Go to PR branch
`yarn install`
`yarn start`
Go to http://localhost:8000/product/white-mecklenburg-bench or any product page
Add the product to your cat and watch the badge on the cart icon. There should be an animation once added. 
Add items to cart until quantity is doube digits, make sure the badge does not entirely cover the cart icon

**Empty Cart**
![image](https://github.com/user-attachments/assets/cb02528d-3834-4b2f-8500-e89313861404)

**Single Digit Cart**
![image](https://github.com/user-attachments/assets/d3b55375-6f24-4bd7-b805-44f6fa8ff116)

**Double Digit Cart**
![image](https://github.com/user-attachments/assets/3fa26b80-efc9-433d-bd07-315edaabc299)
