### PR TITLE
[BUILD-1494] Text Color Fix

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -2,17 +2,17 @@ import * as React from 'react'
 import { Link } from 'gatsby'
 import { PrismicPreviewProvider } from 'gatsby-plugin-prismic-previews'
 import { PrismicProvider } from '@prismicio/react'
-import { ParallaxProvider } from "react-scroll-parallax";
+import { ParallaxProvider } from 'react-scroll-parallax'
 
 import { repositoryConfigs } from './src/utils/prismicPreviews'
 import { linkResolver } from './src/utils/linkResolver'
 
 import './src/base/module.scss'
-import { StoreProvider } from './src/context/store-context';
+import { StoreProvider } from './src/context/store-context'
 
 export const wrapRootElement = ({ element }) => (
   <StoreProvider>
-  <ParallaxProvider>
+    <ParallaxProvider>
       <PrismicProvider
         linkResolver={linkResolver}
         internalLinkComponent={({ href, ...props }) => (
@@ -20,12 +20,19 @@ export const wrapRootElement = ({ element }) => (
         )}
       >
         <PrismicPreviewProvider repositoryConfigs={repositoryConfigs}>
-          
-            {element}
-          
+          {element}
         </PrismicPreviewProvider>
       </PrismicProvider>
-
-  </ParallaxProvider>
+    </ParallaxProvider>
   </StoreProvider>
 )
+
+export const onRenderBody = ({ setHeadComponents }) => {
+  setHeadComponents([
+    <meta
+      name="format-detection"
+      content="telephone=no"
+      key="format-detection"
+    />,
+  ])
+}

--- a/src/components/menus/TopMenu.module.scss
+++ b/src/components/menus/TopMenu.module.scss
@@ -28,7 +28,7 @@
     &:focus {
       transform: translateY(0%);
     }
-  }   
+  }
 }
 .navBar {
   width: 100%;
@@ -74,6 +74,7 @@
   letter-spacing: 10%;
   cursor: pointer;
   white-space: nowrap;
+  color: $color-black;
 
   &:first-child::after {
     content: '';
@@ -106,12 +107,10 @@
   }
 }
 
-
-
 .NavWrap {
   width: 100%;
 
-  //Mobile Nav 
+  //Mobile Nav
   background: $color-cream;
   padding: 5%;
   position: absolute;
@@ -133,7 +132,7 @@
       margin-bottom: 15px;
       display: block;
     }
-  
+
     @media (min-width: $desktop) {
       display: flex;
       flex-wrap: wrap;
@@ -158,12 +157,12 @@
       display: flex;
       align-items: center;
       justify-content: flex-start;
-  
+
       .SocialLink {
         padding-left: 10px;
         padding-right: 10px;
         color: $color-black;
-      }    
+      }
     }
   }
 
@@ -208,7 +207,7 @@
     a {
       padding: 0 10px;
       color: $color-black;
-    }  
+    }
   }
 }
 


### PR DESCRIPTION
**[BUILD-1494] Text Color Fix**
https://app.clickup.com/t/9009201449/BUILD-1494

**Changes**
Added `color: $color-black` to location button so the text doesn't turn blue on mobile
Added `<meta name="format-detection" content="telephone=no">` to keep the (currently not even a hyperlink) phone numbers in the footer from turning into a blue hyperlink. (Got fix from https://stackoverflow.com/questions/3736807/how-do-i-remove-the-blue-styling-of-telephone-numbers-on-iphone-ios)

**NOTES**
My phone is refusing to connect to local out of nowhere so I can't even test this to make sure it works but will try again in a bit and update based on that. 

**Testing**
Pull PR branch
`yarn install`
`yarn start`
Open the site on mobile (pretty sure this is iphone specific issue)
Make sure the location text isn't blue
Scroll to the footer and make sure the phone numbers aren't blue. Both should be black text
