### PR TITLE
[BUILD-1492] Footer Link Fix

### DIFF
--- a/src/components/menus/BottomMenu.js
+++ b/src/components/menus/BottomMenu.js
@@ -14,7 +14,9 @@ export const BottomMenu = ({ menu }) => {
           <div className={sty.contacts}>
             <div className={sty.info}>
               <div className={sty.MenuLinkTitle}>Cayman Islands</div>
-              <p>{menu.caymans_phone}</p>
+              <p>
+                <a href={`tel:${menu.caymans_phone}`}>{menu.caymans_phone}</a>
+              </p>
               <p>{menu.caymans_street}</p>
               <p>{menu.caymans_city}</p>
               <p>{menu.caymans_location}</p>
@@ -22,12 +24,20 @@ export const BottomMenu = ({ menu }) => {
 
             <div className={sty.info}>
               <div className={sty.MenuLinkTitle}>Turks & Caicos</div>
-              <p>{menu.turks_and_caicos_phone}</p>
+              <p>
+                <a href={`tel:${menu.turks_and_caicos_phone}`}>
+                  {menu.turks_and_caicos_phone}
+                </a>
+              </p>
               <p>{menu.turks_and_caicos_complex}</p>
               <p>{menu.turks_and_caicos_street}</p>
               <p>{menu.turks_and_caicos_city}</p>
               <p>{menu.turks_and_caicos_location}</p>
-              <p>{menu.turks_and_caicos_email}</p>
+              <p>
+                <a href={`mailto:${menu.turks_and_caicos_email}`}>
+                  {menu.turks_and_caicos_email}
+                </a>
+              </p>
             </div>
           </div>
         </div>
@@ -84,7 +94,11 @@ export const BottomMenu = ({ menu }) => {
           <div className={sty.bottomBarInfoWrap}>
             <p>
               <span className={sty.helloText}>Say Hello </span>
-              <span className={sty.emailText}>{menu.caymans_email}</span>
+              <span className={sty.emailText}>
+                <a href={`mailto:${menu.caymans_email}`}>
+                  {menu.caymans_email}
+                </a>
+              </span>
             </p>
           </div>
           <div className={sty.bottomBarInfoWrap}>

--- a/src/components/menus/BottomMenu.js
+++ b/src/components/menus/BottomMenu.js
@@ -67,7 +67,7 @@ export const BottomMenu = ({ menu }) => {
                 </li>
               ))}
 
-              <div className={sty.legalTitle}>
+              {/* <div className={sty.legalTitle}>
                 {menu.legal_links_title.text}
               </div>
               <ul className="list-no-style">
@@ -81,7 +81,7 @@ export const BottomMenu = ({ menu }) => {
                     </PrismicLink>
                   </li>
                 ))}
-              </ul>
+              </ul> */}
             </ul>
           </div>
         </div>
@@ -107,7 +107,10 @@ export const BottomMenu = ({ menu }) => {
                 <ul className={`list-no-style ${sty.SocialLinks}`}>
                   {menu.socials.map((item, index) => (
                     <li>
-                      <PrismicLink href={'/'} key={`socialLink:${index}`}>
+                      <PrismicLink
+                        href={item.social_link?.url}
+                        key={`socialLink:${index}`}
+                      >
                         <GatsbyImage
                           image={item?.social_icon?.gatsbyImageData}
                           alt={item.social_icon?.alt || ''}

--- a/src/components/menus/BottomMenu.module.scss
+++ b/src/components/menus/BottomMenu.module.scss
@@ -68,6 +68,7 @@
 
 .linksColumn {
   order: 2;
+
   @media (min-width: $desktop) {
     order: 0;
   }
@@ -100,8 +101,18 @@
 
 .MenuLinks {
   text-align: center;
+
   ul {
     column-count: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    height: 100%;
+    align-items: center;
+    gap: 0;
+    @media (min-width: $desktop) {
+      gap: 20px;
+    }
     li {
       line-height: 180%;
     }

--- a/src/components/menus/BottomMenu.module.scss
+++ b/src/components/menus/BottomMenu.module.scss
@@ -253,3 +253,12 @@
     }
   }
 }
+
+a[href^='mailto:'],
+a[href^='tel:'] {
+  color: $color-greymd;
+  text-decoration: none;
+  &:hover {
+    color: $color-orange;
+  }
+}


### PR DESCRIPTION
**[BUILD-1492] Footer Link Fix**
https://app.clickup.com/t/9009201449/BUILD-1492

**Changes**
Hid Legal section until those links are ready
Made the facebook and instagram icon working links
Made the phone numbers and emails working links

**Notes**
It looks odd on the right side no matter how I put it because its so empty without the legal column but for now I just spaced them out to fill it out more

**Testing**
Go to PR branch
`yarn install`
`yarn start`
Go to http://localhost:8000/ and scroll down to the footer
Make sure both phone numbers in the footer are clickable
Make sure all the emails in the footer are clickable
Make sure the facebook and insta icons both are clickable and take you to FB/Insta

![image](https://github.com/user-attachments/assets/886f3111-deed-4d88-9368-a5e06e0d6f45)

