### PR TITLE
[BUILD-1607] Shop by Room Hover Fix

### DIFF
--- a/src/components/collections-grid/shop-by-room.js
+++ b/src/components/collections-grid/shop-by-room.js
@@ -49,10 +49,8 @@ export const ShopByRoom = ({
                     alt={item.image?.alt || ''}
                   />
                   <div className={sty.overlay}>
-                    <span className={sty.link}>
-                      View Products
-                      <SlArrowRightCircle color="#F68623" size="55px" />
-                    </span>
+                    <span className={sty.link}>View Products</span>
+                    <SlArrowRightCircle color="#F68623" size="55px" />
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
**[BUILD-1607] Shop by Room Hover Fix**
https://app.clickup.com/t/86duwd9bw

**Changes**
Fixed the text in the ShopByRoom hover that was not aligned

**Testing**
Go to PR branch
`yarn install`
`yarn start`
Go to http://localhost:8000/
Hover over the ShopByRoom tiles and make sure the text and arrow look like the updated version and not the unaligned version

**Before**
![image](https://github.com/user-attachments/assets/410f5560-f1b5-4b54-a436-78aee00162d4)

**After**
![image](https://github.com/user-attachments/assets/e4125b6a-8a8c-4998-a70d-827dc4b44241)
