### PR TITLE
[BUILD-1634] Focus Fix

### DIFF
--- a/src/base/_base.scss
+++ b/src/base/_base.scss
@@ -178,3 +178,8 @@ header,
 footer {
   margin: 0 auto;
 }
+
+*:focus {
+  outline: 2px solid black;
+  outline-offset: 3px;
+}

--- a/src/components/menus/BottomMenu.module.scss
+++ b/src/components/menus/BottomMenu.module.scss
@@ -202,7 +202,7 @@
       justify-content: center;
       flex-wrap: wrap;
       max-height: 24px;
-      overflow: hidden;
+
       gap: 15px;
     }
   }

--- a/src/components/menus/TopMenu.module.scss
+++ b/src/components/menus/TopMenu.module.scss
@@ -12,7 +12,7 @@
     border-radius: 0.5em;
     padding: 8px 8px 12px;
     background-color: $color-cream;
-    border: 2px solid $color-rustorange;
+
     color: $color-black;
     font-size: 18px;
     font-weight: 400;

--- a/src/components/menus/TopMenu.module.scss
+++ b/src/components/menus/TopMenu.module.scss
@@ -87,6 +87,13 @@
     font-weight: 700;
   }
 }
+
+.locationBtn:focus {
+  span {
+    outline: 2px solid black;
+    outline-offset: 2px;
+  }
+}
 .activeBtn {
   opacity: 100%;
 }
@@ -211,13 +218,12 @@
   }
 }
 
-.locationBtn:focus {
-  outline: 2px solid black;
-  outline-offset: 2px;
-}
-
 .desktopTablet {
   display: none;
+  &:focus {
+    outline: 2px solid black;
+    outline-offset: 2px;
+  }
 }
 
 .mobile {

--- a/src/components/menus/TopMenu.module.scss
+++ b/src/components/menus/TopMenu.module.scss
@@ -220,10 +220,6 @@
 
 .desktopTablet {
   display: none;
-  &:focus {
-    outline: 2px solid black;
-    outline-offset: 2px;
-  }
 }
 
 .mobile {

--- a/src/components/menus/TopMenu.module.scss
+++ b/src/components/menus/TopMenu.module.scss
@@ -212,7 +212,7 @@
 }
 
 .locationBtn:focus {
-  outline: 2px solid #d3005b; /* Example focus outline */
+  outline: 2px solid black;
   outline-offset: 2px;
 }
 

--- a/src/components/menus/TopMenu.module.scss
+++ b/src/components/menus/TopMenu.module.scss
@@ -50,6 +50,7 @@
     gap: 20px;
     align-items: center;
     width: 50%;
+    white-space: nowrap;
     @media (max-width: $desktop) {
       width: 100%;
     }


### PR DESCRIPTION
**[BUILD-1634] Focus Fix**
https://app.clickup.com/t/9009201449/BUILD-1634

**Changes**
Fixed the focus styling that was put on the social links that didn't match
Fixed the footer social links focus styles also which were getting cut off
![image](https://github.com/user-attachments/assets/386a153e-62ef-4216-951d-9b2655309e73)

**Testing**
Go to PR branch
`yarn install`
`yarn start`
Go to http://localhost:8000/
View the focus styles on the top menu location buttons, it should be black and match the other focus styles
View the focus styles on the bottom menu social buttons, they should also show and match

